### PR TITLE
fix: fix bug of multi-round conversation in api demo

### DIFF
--- a/moss_api_demo.py
+++ b/moss_api_demo.py
@@ -81,7 +81,7 @@ async def create_item(request: Request):
         history_mp[uid] = []
     for i, (old_query, response) in enumerate(history_mp[uid]):
         prompt += '<|Human|>: ' + old_query + '<eoh>'+response
-    prompt = '<|Human|>: ' + query + '<eoh>'
+    prompt += '<|Human|>: ' + query + '<eoh>'
     max_length = json_post_list.get('max_length', 2048)
     top_p = json_post_list.get('top_p', 0.8)
     temperature = json_post_list.get('temperature', 0.7)


### PR DESCRIPTION
I made a mistake in the previous API demo. I forgot to include the history and meta-instructions in the prompt.